### PR TITLE
Update for latest version of napping

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -33,9 +33,6 @@ func NewClient(opts ClientOptions) *Client {
 		Userinfo: url.UserPassword(opts.Username, opts.Password),
 		Header:   &http.Header{},
 		Client:   &http.Client{},
-
-		// Authorize use of client to HTTP endpoints
-		UnsafeBasicAuth: true,
 	}
 
 	// We want JSON responses (for errors especially)


### PR DESCRIPTION
Changes to package `napping` make setting `Session.UnsafeBasicAuth` no longer required or supported.
